### PR TITLE
fix: treat certificateRequest notFound error

### DIFF
--- a/internal/controller/challenge_controller.go
+++ b/internal/controller/challenge_controller.go
@@ -269,7 +269,7 @@ func (r *ChallengeReconciler) getIssuerForChallenge(ctx context.Context, challen
 	// In a real implementation, you might want to store the full reference including namespace
 	cr := &cmapi.CertificateRequest{}
 	if err := r.Get(ctx, client.ObjectKey{Namespace: challenge.Namespace, Name: crName}, cr); err != nil {
-		return nil, fmt.Errorf("failed to get CertificateRequest: %v", err)
+		return nil, fmt.Errorf("failed to get CertificateRequest: %w", err)
 	}
 
 	// Get the issuer reference kind (default to "Issuer" if not specified)
@@ -448,10 +448,25 @@ func (r *ChallengeReconciler) cleanupDNSRecords(ctx context.Context, challenge *
 	logger := log.FromContext(ctx)
 	logger.Info("Cleaning up DNS records for challenge", "namespace", challenge.Namespace, "name", challenge.Name)
 
-	// First, get the issuer to access Route53 configuration
+	// Get the issuer to access Route53 configuration.
+	// If the CertificateRequest is already gone we cannot resolve the issuer's Route53
+	// config. There is nothing left to protect, so skip DNS cleanup and allow the
+	// finalizer to be removed.
 	issuer, err := r.getIssuerForChallenge(ctx, challenge)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("CertificateRequest no longer exists, skipping DNS cleanup",
+				"certificateRequest", challenge.Spec.CertificateRequestRef)
+			return nil
+		}
 		return fmt.Errorf("failed to get issuer during cleanup: %v", err)
+	}
+
+	// Use the same namespace logic as applyRoute53CNAMERecord: ClusterIssuer secrets
+	// live in the cert-manager namespace, not in the challenge namespace.
+	secretNamespace := challenge.Namespace
+	if issuer.Namespace == "" {
+		secretNamespace = CertManagerNamespace
 	}
 
 	// Delete all validation records
@@ -466,14 +481,11 @@ func (r *ChallengeReconciler) cleanupDNSRecords(ctx context.Context, challenge *
 
 		route53Config := solver.DNS01.Route53
 
-		// Delete CNAME record
-		err := r.deleteRoute53CNAMERecord(ctx, route53Config, validationRecord.CNAMEName, validationRecord.CNAMEValue, challenge.Namespace)
-		if err != nil {
+		if err := r.deleteRoute53CNAMERecord(ctx, route53Config, validationRecord.CNAMEName, validationRecord.CNAMEValue, secretNamespace); err != nil {
 			logger.Error(err, "Failed to delete Route53 CNAME record",
 				"domain", domain,
 				"source", validationRecord.CNAMEName,
 				"target", validationRecord.CNAMEValue)
-			// Continue with other records even if one fails
 			continue
 		}
 

--- a/internal/controller/challenge_controller_test.go
+++ b/internal/controller/challenge_controller_test.go
@@ -18,13 +18,25 @@ package controller
 
 import (
 	"context"
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	sigs_client "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	zerosslv1alpha1 "github.com/topfreegames/zerossl-issuer/api/v1alpha1"
 	"github.com/topfreegames/zerossl-issuer/internal/zerossl"
@@ -105,3 +117,116 @@ var _ = Describe("Challenge Controller", func() {
 		})
 	})
 })
+
+// newChallengeTestScheme builds the runtime scheme needed by challenge controller tests.
+func newChallengeTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(s))
+	require.NoError(t, cmapi.AddToScheme(s))
+	require.NoError(t, cmmeta.AddToScheme(s))
+	require.NoError(t, zerosslv1alpha1.AddToScheme(s))
+	return s
+}
+
+// newChallengeReconcilerWithObjects creates a ChallengeReconciler backed by a fake
+// client pre-populated with the given objects.
+func newChallengeReconcilerWithObjects(t *testing.T, objs ...sigs_client.Object) *ChallengeReconciler {
+	t.Helper()
+	s := newChallengeTestScheme(t)
+	fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+	return NewChallengeReconciler(fakeClient, s, record.NewFakeRecorder(10), 1)
+}
+
+// TestCleanupDNSRecords_SkipsWhenCertificateRequestNotFound verifies the fix for
+// Challenges getting permanently stuck in Terminating when their parent
+// CertificateRequest was already deleted before the finalizer ran.
+func TestCleanupDNSRecords_SkipsWhenCertificateRequestNotFound(t *testing.T) {
+	reconciler := newChallengeReconcilerWithObjects(t) // empty fake client — no CR exists
+
+	challenge := &zerosslv1alpha1.Challenge{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-challenge",
+			Namespace: "default",
+		},
+		Spec: zerosslv1alpha1.ChallengeSpec{
+			CertificateRequestRef: "nonexistent-cr",
+			CertificateID:         "test-cert-id",
+			ValidationMethod:      "DNS",
+			ValidationRecords: []zerosslv1alpha1.ValidationRecord{
+				{
+					Domain:     "example.com",
+					CNAMEName:  "_zerossl.example.com",
+					CNAMEValue: "abc.zerossl.com",
+				},
+			},
+		},
+	}
+
+	err := reconciler.cleanupDNSRecords(context.Background(), challenge)
+	assert.NoError(t, err, "cleanupDNSRecords must return nil when the CertificateRequest is gone so the finalizer can be removed")
+}
+
+// TestGetIssuerForChallenge_ErrorIsUnwrappableAsNotFound verifies that when the
+// CertificateRequest referenced by a Challenge does not exist, the error from
+// getIssuerForChallenge is wrapped with %%w so apierrors.IsNotFound identifies it
+// through the chain — allowing cleanupDNSRecords to distinguish missing CRs from
+// transient API failures.
+func TestGetIssuerForChallenge_ErrorIsUnwrappableAsNotFound(t *testing.T) {
+	reconciler := newChallengeReconcilerWithObjects(t) // empty fake client — no CR exists
+
+	challenge := &zerosslv1alpha1.Challenge{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-challenge", Namespace: "default"},
+		Spec:       zerosslv1alpha1.ChallengeSpec{CertificateRequestRef: "nonexistent-cr"},
+	}
+
+	_, err := reconciler.getIssuerForChallenge(context.Background(), challenge)
+	require.Error(t, err)
+	assert.True(t, apierrors.IsNotFound(err),
+		"error must unwrap to a NotFound API error; got: %v", err)
+}
+
+// TestGetIssuerForChallenge_ClusterIssuerHasEmptyNamespace verifies that when the
+// CertificateRequest references a ClusterIssuer, getIssuerForChallenge returns an
+// Issuer with an empty namespace. cleanupDNSRecords uses that empty namespace as the
+// signal to look up AWS secrets in cert-manager namespace rather than the challenge
+// namespace.
+func TestGetIssuerForChallenge_ClusterIssuerHasEmptyNamespace(t *testing.T) {
+	clusterIssuer := &zerosslv1alpha1.ClusterIssuer{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cluster-issuer"},
+		Spec: zerosslv1alpha1.ClusterIssuerSpec{
+			IssuerSpec: zerosslv1alpha1.IssuerSpec{
+				APIKeySecretRef: corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "zerossl-api-key"},
+					Key:                  "api-key",
+				},
+			},
+		},
+		Status: zerosslv1alpha1.ClusterIssuerStatus{
+			Conditions: []metav1.Condition{{Type: "Ready", Status: metav1.ConditionTrue}},
+		},
+	}
+
+	cr := &cmapi.CertificateRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-cr", Namespace: "some-app"},
+		Spec: cmapi.CertificateRequestSpec{
+			IssuerRef: cmmeta.ObjectReference{
+				Name:  "test-cluster-issuer",
+				Kind:  "ClusterIssuer",
+				Group: zerosslv1alpha1.GroupVersion.Group,
+			},
+		},
+	}
+
+	reconciler := newChallengeReconcilerWithObjects(t, clusterIssuer, cr)
+
+	challenge := &zerosslv1alpha1.Challenge{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-challenge", Namespace: "some-app"},
+		Spec:       zerosslv1alpha1.ChallengeSpec{CertificateRequestRef: "test-cr"},
+	}
+
+	issuer, err := reconciler.getIssuerForChallenge(context.Background(), challenge)
+	require.NoError(t, err)
+	assert.Empty(t, issuer.Namespace,
+		"ClusterIssuer must produce an issuer with empty namespace so AWS secrets are resolved from cert-manager namespace, not the challenge namespace")
+}


### PR DESCRIPTION
- Fix `cleanupDNSRecords` skipping DNS cleanup when the parent `CertificateRequest` no longer exists, preventing `Challenge` resources from getting permanently stuck in `Terminating` and causing repeated controller restarts.
- Fix incorrect AWS secret namespace during DNS cleanup for `ClusterIssuer`-backed challenges — credentials were looked up in the challenge namespace instead of `cert-manager`, mirroring the logic already used on record creation.
- Refactor `getIssuerForChallenge` to wrap the `CertificateRequest` lookup error with `%w` so callers can inspect the underlying API error (e.g. `IsNotFound`) without a redundant pre-fetch.