### PR TITLE
fix: Enforce issuing cross-signed CA cert for older devices

### DIFF
--- a/helm/zerossl-issuer/Chart.yaml
+++ b/helm/zerossl-issuer/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: zerossl-issuer
 description: A Helm chart for the ZeroSSL cert-manager Issuer
 type: application
-version: 0.2.3
-appVersion: "0.2.1"
+version: 0.2.4
+appVersion: "0.2.2"
 keywords:
   - zerossl
   - cert-manager

--- a/internal/zerossl/certificates.go
+++ b/internal/zerossl/certificates.go
@@ -153,7 +153,9 @@ func (c *Client) GetCertificate(id string) (*CertificateResponse, error) {
 
 // DownloadCertificate downloads the certificate and CA bundle for a given certificate ID
 func (c *Client) DownloadCertificate(id string) (*DownloadCertificateResponse, error) {
-	endpoint := fmt.Sprintf("%s/certificates/%s/download/return?access_key=%s", BaseURL, id, c.apiKey)
+	// include_cross_signed=1 appends the Sectigo R46 cert cross-signed by USERTrust
+	// so older trust stores (e.g. Android predating Sectigo R46) still validate the chain.
+	endpoint := fmt.Sprintf("%s/certificates/%s/download/return?access_key=%s&include_cross_signed=1", BaseURL, id, c.apiKey)
 
 	resp, err := c.httpClient.Get(endpoint)
 	if err != nil {


### PR DESCRIPTION
Older devices fails with new certificates that don't have the cross-signed CA certificates in the chain
This PR enforces the controller to download the full chain with the cross-signed

- https://help.zerossl.com/hc/en-us/articles/360060198034-Legacy-Client-Compatibility-Cross-Signed-Root-Certificates